### PR TITLE
feat(output): complete human-readable formatter

### DIFF
--- a/internal/output/formatters_test.go
+++ b/internal/output/formatters_test.go
@@ -69,16 +69,17 @@ func TestHumanFormatter_V1(t *testing.T) {
 
 	mustContain := []string{
 		divider,
+		"SNMP Trap Received",
 		"Version:    v1",
 		"Source:     10.0.0.10:55000",
 		"Community:  public",
 		"Enterprise: .1.3.6.1.4.1.9",
 		"Agent:      10.0.0.5",
-		"Generic:    6",
+		"enterpriseSpecific",
 		"Specific:   1",
-		"Timestamp:  6000 timeticks",
+		"6000 (1m0s)",
 		"Varbinds:",
-		"ciscoMgmt",     // resolved name used
+		"ciscoMgmt",          // resolved name used
 		".1.3.6.1.4.1.9.2.0", // raw OID for unresolved
 	}
 	for _, s := range mustContain {
@@ -107,7 +108,7 @@ func TestHumanFormatter_V2c(t *testing.T) {
 		"Version:    v2c",
 		"Trap OID:   .1.3.6.1.4.1.9.9.1",
 		"Community:  public",
-		"Timestamp:  360000 timeticks",
+		"360000 (1h0m0s)",
 	}
 	for _, s := range mustContain {
 		if !strings.Contains(out, s) {

--- a/internal/output/human.go
+++ b/internal/output/human.go
@@ -3,12 +3,18 @@ package output
 import (
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/cblauvelt/snmp-trap-printer/internal/trap"
 	"github.com/gosnmp/gosnmp"
 )
 
-const divider = "--------------------------------------------------------------------------------"
+const divider = "================================================================================"
+
+var genericTrapNames = [...]string{
+	"coldStart", "warmStart", "linkDown", "linkUp",
+	"authenticationFailure", "egpNeighborLoss", "enterpriseSpecific",
+}
 
 // HumanFormatter writes labeled KV blocks to stdout, one per trap.
 type HumanFormatter struct{}
@@ -18,6 +24,8 @@ func NewHumanFormatter() *HumanFormatter { return &HumanFormatter{} }
 
 // Format writes a human-readable block for t.
 func (h *HumanFormatter) Format(w io.Writer, t *trap.Trap) error {
+	fmt.Fprintln(w, divider)
+	fmt.Fprintln(w, "SNMP Trap Received")
 	fmt.Fprintln(w, divider)
 	fmt.Fprintf(w, "Version:    %s\n", versionString(t.Version))
 	fmt.Fprintf(w, "Source:     %s\n", t.SourceIP)
@@ -32,11 +40,11 @@ func (h *HumanFormatter) Format(w io.Writer, t *trap.Trap) error {
 		fmt.Fprintf(w, "Agent:      %s\n", t.AgentAddress)
 	}
 	if t.Version == gosnmp.Version1 {
-		fmt.Fprintf(w, "Generic:    %d\n", t.GenericType)
+		fmt.Fprintf(w, "Generic:    %s (%d)\n", genericTrapName(t.GenericType), t.GenericType)
 		fmt.Fprintf(w, "Specific:   %d\n", t.SpecificType)
 	}
 	if t.Timestamp > 0 {
-		fmt.Fprintf(w, "Timestamp:  %d timeticks\n", t.Timestamp)
+		fmt.Fprintf(w, "Timestamp:  %s\n", formatTimeticks(t.Timestamp))
 	}
 	if t.OID != "" {
 		fmt.Fprintf(w, "Trap OID:   %s\n", t.OID)
@@ -50,7 +58,7 @@ func (h *HumanFormatter) Format(w io.Writer, t *trap.Trap) error {
 
 	if len(t.Varbinds) > 0 {
 		fmt.Fprintln(w, "Varbinds:")
-		for _, vb := range t.Varbinds {
+		for i, vb := range t.Varbinds {
 			name := vb.OID
 			if vb.Name != "" {
 				name = vb.Name
@@ -59,11 +67,23 @@ func (h *HumanFormatter) Format(w io.Writer, t *trap.Trap) error {
 			if val == "" {
 				val = fmt.Sprintf("%v", vb.Value)
 			}
-			fmt.Fprintf(w, "  %-40s %s\n", name, val)
+			fmt.Fprintf(w, "  [%d] %s (%s)\n      %s\n", i+1, name, berTypeName(vb.Type), val)
 		}
 	}
 	fmt.Fprintln(w, divider)
 	return nil
+}
+
+func formatTimeticks(ticks uint) string {
+	d := time.Duration(ticks) * 10 * time.Millisecond
+	return fmt.Sprintf("%d (%s)", ticks, d)
+}
+
+func genericTrapName(n int) string {
+	if n >= 0 && n < len(genericTrapNames) {
+		return genericTrapNames[n]
+	}
+	return fmt.Sprintf("%d", n)
 }
 
 func versionString(v gosnmp.SnmpVersion) string {


### PR DESCRIPTION
## Summary

- Change divider to `=` chars and add `SNMP Trap Received` header between two dividers
- Format timetick timestamps with human-friendly duration alongside the raw value (e.g. `6000 (1m0s)`)
- Display v1 generic trap type as `name (number)` (e.g. `enterpriseSpecific (6)`) using the standard SNMP generic trap name table
- Number varbinds and include the ASN.1 type in parens, with the value indented on its own line

Closes #9

## Test plan

- [x] `TestHumanFormatter_V1` — verifies header, divider, v1 fields, generic trap name, timetick duration, varbind name resolution
- [x] `TestHumanFormatter_V2c` — verifies v2c fields, timetick duration, absent v1/v3 fields
- [x] `TestHumanFormatter_V3` — verifies v3 security/context fields, absent community
- [x] `TestHumanFormatter_ZeroTimestamp` — zero timestamp omitted from output
- [x] `TestHumanFormatter_VarbindNameFallback` — name used when set, raw OID when not
- [x] `TestHumanFormatter_NoVarbinds` — varbinds section omitted when empty
- [x] `TestHumanFormatter_ReturnsNilError` — Format always returns nil
- [x] `TestHumanFormatter_UsesFormattedValue` — FormattedValue takes priority over raw Value