### PR TITLE
Add docker-compose.yml to deploy directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,62 @@ export SNMP_V3_PRIV_PASSWORD=privsecret
 ./build/snmp-trap-printer --port 10162
 ```
 
+## MIBs
+
+Standard MIBs are loaded automatically from OS default paths if they exist:
+
+| OS | Paths |
+|----|-------|
+| Linux | `/usr/share/snmp/mibs`, `/usr/local/share/snmp/mibs` |
+| macOS | `/usr/local/share/snmp/mibs`, `/opt/homebrew/share/snmp/mibs` |
+| Windows | `C:\usr\mibs`, `%APPDATA%\snmp\mibs` |
+
+If no MIBs are found, the tool runs normally and displays raw numeric OIDs and values instead of names.
+
+Install standard MIBs:
+```bash
+# macOS
+brew install net-snmp
+
+# Debian / Ubuntu
+sudo apt-get install snmp-mibs-downloader
+sudo download-mibs
+```
+
+## Docker
+
+A `deploy/docker-compose.yml` is provided for running the container without building manually. The image bundles standard MIBs from `deploy/files/` — host MIB paths are not used.
+
+```bash
+# Human output (default), listening on UDP 10162
+cd deploy && docker compose up
+
+# JSON (NDJSON) output
+cd deploy && OUTPUT_FORMAT=json docker compose up
+
+# SNMPv3 authPriv with JSON output
+cd deploy && OUTPUT_FORMAT=json \
+  SNMP_V3_USERNAME=trapuser \
+  SNMP_V3_AUTH_PROTOCOL=SHA256 \
+  SNMP_V3_AUTH_PASSWORD=authsecret \
+  SNMP_V3_PRIV_PROTOCOL=AES \
+  SNMP_V3_PRIV_PASSWORD=privsecret \
+  docker compose up
+```
+
+To listen on the privileged port 162 on the host, change the port mapping in `docker-compose.yml` to `"162:10162/udp"` and add `cap_add: [NET_BIND_SERVICE]`.
+
+To load additional MIBs, mount a directory into the container and pass `--mib-path` via the `command` override:
+
+```yaml
+services:
+  snmp-trap-printer:
+    # ...
+    volumes:
+      - /path/to/your/mibs:/mibs:ro
+    command: ["--port", "10162", "--mib-path", "/mibs"]
+```
+
 ## Sending sample traps
 
 The examples below use `snmptrap` from the [net-snmp](http://www.net-snmp.org/) package.
@@ -175,26 +231,4 @@ One JSON object per line (NDJSON), suitable for piping to `jq` or ingestion by l
 Filter with `jq`:
 ```bash
 ./build/snmp-trap-printer --port 10162 --output json | jq '.varbinds[] | {name, value}'
-```
-
-## MIBs
-
-Standard MIBs are loaded automatically from OS default paths if they exist:
-
-| OS | Paths |
-|----|-------|
-| Linux | `/usr/share/snmp/mibs`, `/usr/local/share/snmp/mibs` |
-| macOS | `/usr/local/share/snmp/mibs`, `/opt/homebrew/share/snmp/mibs` |
-| Windows | `C:\usr\mibs`, `%APPDATA%\snmp\mibs` |
-
-If no MIBs are found, the tool runs normally and displays raw numeric OIDs and values instead of names.
-
-Install standard MIBs:
-```bash
-# macOS
-brew install net-snmp
-
-# Debian / Ubuntu
-sudo apt-get install snmp-mibs-downloader
-sudo download-mibs
 ```

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  snmp-trap-printer:
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile
+    ports:
+      - "10162:10162/udp"
+    restart: unless-stopped
+    environment:
+      - OUTPUT_FORMAT=${OUTPUT_FORMAT:-human}
+      - SNMP_V3_USERNAME=${SNMP_V3_USERNAME:-}
+      - SNMP_V3_AUTH_PROTOCOL=${SNMP_V3_AUTH_PROTOCOL:-}
+      - SNMP_V3_AUTH_PASSWORD=${SNMP_V3_AUTH_PASSWORD:-}
+      - SNMP_V3_PRIV_PROTOCOL=${SNMP_V3_PRIV_PROTOCOL:-}
+      - SNMP_V3_PRIV_PASSWORD=${SNMP_V3_PRIV_PASSWORD:-}
+    # To listen on the privileged port 162 on the host instead of 10162, change
+    # the port mapping above to "162:10162/udp" and add:
+    #   cap_add:
+    #     - NET_BIND_SERVICE

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,7 +100,11 @@ func Parse() *Config {
 
 	flag.StringVar(&cfg.Address, "address", "0.0.0.0", "Bind address")
 	flag.UintVar(&port, "port", 162, "UDP port")
-	flag.StringVar(&output, "output", "human", "Output format: human or json")
+	outputDefault := os.Getenv("OUTPUT_FORMAT")
+	if outputDefault == "" {
+		outputDefault = string(OutputHuman)
+	}
+	flag.StringVar(&output, "output", outputDefault, fmt.Sprintf("Output format: %s or %s", OutputHuman, OutputJSON))
 	flag.Var(&mibPaths, "mib-path", "Extra MIB directory (repeatable)")
 	flag.Parse()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -98,6 +98,41 @@ func TestParseOutputInvalid(t *testing.T) {
 	}
 }
 
+// TestParseOutputFormatEnvVar verifies that OUTPUT_FORMAT env var sets the output format.
+func TestParseOutputFormatEnvVar(t *testing.T) {
+	if os.Getenv("TEST_PARSE_OUTPUT_FORMAT_ENV") == "1" {
+		cfg := Parse()
+		if cfg.Output != OutputJSON {
+			t.Fatalf("output: got %q, want %q", cfg.Output, OutputJSON)
+		}
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestParseOutputFormatEnvVar")
+	cmd.Env = append(os.Environ(), "TEST_PARSE_OUTPUT_FORMAT_ENV=1", "OUTPUT_FORMAT=json")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("subprocess failed: %v\n%s", err, out)
+	}
+}
+
+// TestParseFlagOverridesOutputFormatEnvVar verifies that --output flag takes precedence over OUTPUT_FORMAT env var.
+func TestParseFlagOverridesOutputFormatEnvVar(t *testing.T) {
+	if os.Getenv("TEST_PARSE_FLAG_OVERRIDES_ENV") == "1" {
+		os.Args = []string{"snmp-trap-printer", "--output", "human"}
+		cfg := Parse()
+		if cfg.Output != OutputHuman {
+			t.Fatalf("output: got %q, want %q", cfg.Output, OutputHuman)
+		}
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestParseFlagOverridesOutputFormatEnvVar")
+	cmd.Env = append(os.Environ(), "TEST_PARSE_FLAG_OVERRIDES_ENV=1", "OUTPUT_FORMAT=json")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("subprocess failed: %v\n%s", err, out)
+	}
+}
+
 // TestParseMIBPaths verifies that --mib-path can be specified multiple times.
 func TestParseMIBPaths(t *testing.T) {
 	if os.Getenv("TEST_PARSE_MIB_PATHS") == "1" {


### PR DESCRIPTION
## Summary

- Add `deploy/docker-compose.yml` with UDP port 10162, `restart: unless-stopped`, and all `SNMP_V3_*` env vars passed through from the host
- Support `OUTPUT_FORMAT` env var in `config.Parse()` as the default for `--output`; CLI flag still takes precedence
- Document Docker usage in README; move `## MIBs` section above `## Docker` to clarify host paths are not used by the container

## Test plan

- [x] `go test ./internal/config/...` — includes `TestParseOutputFormatEnvVar` and `TestParseFlagOverridesOutputFormatEnvVar`

Closes #28