### PR TITLE
Add Docker Hub publish workflow and docs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,59 @@
+name: Docker Build and Publish
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*.*.*"]
+  pull_request:
+    branches: [main]
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: cblauvelt/snmp-trap-printer
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU (for multi-platform)
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request' && env.ACT != 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push Docker image
+        if: env.ACT != 'true'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: deploy/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build:
 
 ## docker: Build the Docker image and tag as latest
 docker:
-	docker build -f deploy/Dockerfile -t $(BINARY):latest .
+	docker build -f deploy/Dockerfile -t cblauvelt/$(BINARY):latest .
 
 ## run: Build and run with --port 10162 (no sudo required)
 run: build

--- a/README.md
+++ b/README.md
@@ -110,6 +110,51 @@ sudo download-mibs
 
 ## Docker
 
+### Pull from Docker Hub
+
+Pre-built images are published to [Docker Hub](https://hub.docker.com/r/cblauvelt/snmp-trap-printer) for `linux/amd64` and `linux/arm64`.
+
+```bash
+docker pull cblauvelt/snmp-trap-printer:latest
+```
+
+#### Basic usage
+
+```bash
+# Human output, listening on UDP 10162
+docker run --rm -p 10162:10162/udp cblauvelt/snmp-trap-printer:latest
+
+# JSON (NDJSON) output
+docker run --rm -p 10162:10162/udp \
+  -e OUTPUT_FORMAT=json \
+  cblauvelt/snmp-trap-printer:latest
+```
+
+#### With a custom MIB directory
+
+Mount a host directory into the container and pass `--mib-path` to load additional MIBs:
+
+```bash
+docker run --rm -p 10162:10162/udp \
+  -v /path/to/your/mibs:/mibs:ro \
+  cblauvelt/snmp-trap-printer:latest \
+  --port 10162 --mib-path /mibs
+```
+
+The `--mib-path` flag is repeatable if you have MIBs spread across multiple directories:
+
+```bash
+docker run --rm -p 10162:10162/udp \
+  -v /opt/vendor/mibs:/vendor-mibs:ro \
+  -v /opt/local/mibs:/local-mibs:ro \
+  cblauvelt/snmp-trap-printer:latest \
+  --port 10162 --mib-path /vendor-mibs --mib-path /local-mibs
+```
+
+The image already bundles standard MIBs (IF-MIB, IP-MIB, SNMPv2-MIB, etc.) — you only need to mount a directory when you have device- or vendor-specific MIBs beyond the defaults.
+
+### docker-compose
+
 A `deploy/docker-compose.yml` is provided for running the container without building manually. The image bundles standard MIBs from `deploy/files/` — host MIB paths are not used.
 
 ```bash

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: ..
       dockerfile: deploy/Dockerfile
+      tags:
+        - cblauvelt/snmp-trap-printer
     ports:
       - "10162:10162/udp"
     restart: unless-stopped

--- a/docs/dockerhub-description.md
+++ b/docs/dockerhub-description.md
@@ -1,0 +1,70 @@
+A lightweight CLI tool that listens for SNMP traps (v1, v2c, v3) on a UDP port and prints each trap to stdout as it arrives. Designed for troubleshooting trap pipelines, verifying trap contents, and demoing SNMP integrations without needing a full NMS.
+
+## Features
+
+- Supports SNMPv1, v2c, and v3 (noAuthNoPriv, authNoPriv, authPriv)
+- Human-readable labeled key-value output or machine-readable NDJSON
+- OID-to-name resolution via bundled standard MIBs (IF-MIB, IP-MIB, SNMPv2-MIB, etc.)
+- MIB-aware value formatting: enum names, units, timetick durations, hex for binary data
+- Mount a directory of custom/vendor MIBs for device-specific OID resolution
+- Graceful degradation — raw OIDs and values shown when a MIB is unavailable
+
+## Quick Start
+
+```bash
+# Human-readable output on UDP port 10162
+docker run --rm -p 10162:10162/udp cblauvelt/snmp-trap-printer:latest
+
+# NDJSON output (pipe to jq, log collectors, etc.)
+docker run --rm -p 10162:10162/udp \
+  -e OUTPUT_FORMAT=json \
+  cblauvelt/snmp-trap-printer:latest
+```
+
+## Custom MIB Directory
+
+Mount a host directory and pass `--mib-path` to load vendor or device-specific MIBs:
+
+```bash
+docker run --rm -p 10162:10162/udp \
+  -v /path/to/your/mibs:/mibs:ro \
+  cblauvelt/snmp-trap-printer:latest \
+  --port 10162 --mib-path /mibs
+```
+
+## SNMPv3
+
+Set credentials via environment variables:
+
+```bash
+docker run --rm -p 10162:10162/udp \
+  -e SNMP_V3_USERNAME=trapuser \
+  -e SNMP_V3_AUTH_PROTOCOL=SHA256 \
+  -e SNMP_V3_AUTH_PASSWORD=authsecret \
+  -e SNMP_V3_PRIV_PROTOCOL=AES \
+  -e SNMP_V3_PRIV_PASSWORD=privsecret \
+  cblauvelt/snmp-trap-printer:latest
+```
+
+| Variable | Description |
+|----------|-------------|
+| `SNMP_V3_USERNAME` | USM username |
+| `SNMP_V3_AUTH_PROTOCOL` | `MD5`, `SHA`, `SHA224`, `SHA256`, `SHA384`, `SHA512` |
+| `SNMP_V3_AUTH_PASSWORD` | Authentication passphrase |
+| `SNMP_V3_PRIV_PROTOCOL` | `DES`, `AES`, `AES192`, `AES256` |
+| `SNMP_V3_PRIV_PASSWORD` | Privacy passphrase |
+
+Security level is inferred automatically from the variables provided.
+
+## CLI Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--address` | `0.0.0.0` | UDP bind address |
+| `--port` | `162` | UDP port (use 10162 to avoid requiring NET_BIND_SERVICE) |
+| `--output` | `human` | `human` or `json` |
+| `--mib-path` | _(bundled)_ | Extra MIB directory; repeatable |
+
+## Source
+
+[github.com/cblauvelt/snmp-trap-printer](https://github.com/cblauvelt/snmp-trap-printer)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/docker-publish.yml` to build and push multi-platform images (`linux/amd64`, `linux/arm64`) to Docker Hub on push to `main` or version tags
- Adds `docs/dockerhub-description.md` with a paste-ready repository description for the Docker Hub listing
- Expands README Docker section with pull/run instructions and a custom MIB directory example
- Tags the image as `cblauvelt/snmp-trap-printer` in `Makefile` and `docker-compose.yml`

Closes #31

## Test plan

- [x] `gh act push -j build-and-publish` runs successfully locally (QEMU, Buildx, metadata steps all pass; build/push skipped as expected when running under act)